### PR TITLE
Changed purly to purely in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 * Mediahub Developer Docs: http://mediahub.unl.edu/developers
 
 ### Deployment
-Because this project is purly js and html, deployment is pretty darn easy.  All you have to do is put it in a directory on the live server.
+Because this project is purely js and html, deployment is pretty darn easy.  All you have to do is put it in a directory on the live server.
 
 ### Contacts
 * Current Developer: Craig Eiting


### PR DESCRIPTION
In deployment section in README.md it was written this project is purly js and html, deployment is pretty darn easy.
So,instead of purly it must be purely.